### PR TITLE
Expose real audio technical tags through EchoLink that can display them on the mobile playback/library UI.

### DIFF
--- a/src/main/connect/EchoLinkService.ts
+++ b/src/main/connect/EchoLinkService.ts
@@ -3319,6 +3319,10 @@ export class EchoLinkService {
       durationMs: statusDurationMs > 0 ? statusDurationMs : Math.max(0, Math.round((fallbackTrack?.duration ?? 0) * 1000)),
       sourceLabel: fallbackTrack ? sourceLabelForTrack(fallbackTrack) : 'Current Playback',
       canPlayOnPhone: fallbackTrack ? canPlayOnPhone(fallbackTrack) : Boolean(audioStatus.currentFilePath && existsSync(audioStatus.currentFilePath)),
+      codec: fallbackTrack?.codec ?? null,
+      sampleRate: fallbackTrack?.sampleRate ?? null,
+      bitDepth: fallbackTrack?.bitDepth ?? null,
+      bitrate: fallbackTrack?.bitrate ?? null,
     };
   }
 
@@ -3383,6 +3387,10 @@ export class EchoLinkService {
       durationMs: Math.max(0, Math.round((track.duration ?? 0) * 1000)),
       sourceLabel: sourceLabelForTrack(track),
       canPlayOnPhone: canPlayOnPhone(track),
+      codec: track.codec,
+      sampleRate: track.sampleRate,
+      bitDepth: track.bitDepth,
+      bitrate: track.bitrate,
     };
   }
 

--- a/src/shared/types/echoLink.ts
+++ b/src/shared/types/echoLink.ts
@@ -15,6 +15,10 @@ export type EchoLinkTrackPreview = {
   durationMs: number;
   sourceLabel: string;
   canPlayOnPhone: boolean;
+  codec?: string | null;
+  sampleRate?: number | null;
+  bitDepth?: number | null;
+  bitrate?: number | null;
 };
 
 export type EchoLinkAlbumPreview = {


### PR DESCRIPTION
# About it

Purpose: expose real audio technical tags through EchoLink and display them on the mobile playback/library UI.
(In situations like streaming and so on)

Changed files here:

- ECHO/src/shared/types/echoLink.ts
- ECHO/src/main/connect/EchoLinkService.ts

Desktop EchoLink now includes these LibraryTrack fields in track previews when available:

- codec: FLAC / MP3 / ALAC / etc.
- sampleRate: raw Hz value, displayed on mobile as 44.1kHz / 48kHz / 96kHz
- bitDepth: displayed as 16bit / 24bit
- bitrate: raw bps value, displayed on mobile as kbps