### PR TITLE
fix: restore taskbar thumbnail controls after closing mini player

### DIFF
--- a/src/main/app/miniPlayerWindow.ts
+++ b/src/main/app/miniPlayerWindow.ts
@@ -6,6 +6,7 @@ import { getAppSettings, setAppSettings } from './appSettings';
 import { createMainWindow, createMainWindowWebPreferences } from './createMainWindow';
 import { ensureTray } from './tray';
 import { getMainWindow } from './windowManager';
+import { refreshTaskbarPlaybackIntegration } from './taskbarPlaybackIntegration';
 import { recordMainRuntimeIssue, recordRendererConsoleMessage } from '../diagnostics/DevConsoleService';
 
 const mainOutputDir = import.meta.dirname;
@@ -194,6 +195,7 @@ const restoreMainWindowAfterMiniPlayerHide = (): void => {
   mainWindow.show();
   mainWindow.moveTop();
   mainWindow.focus();
+  refreshTaskbarPlaybackIntegration();
 };
 
 const rememberMiniPlayerBounds = (window: BrowserWindow): void => {

--- a/src/main/app/taskbarPlaybackIntegration.ts
+++ b/src/main/app/taskbarPlaybackIntegration.ts
@@ -275,6 +275,7 @@ export class TaskbarPlaybackIntegration {
       return;
     }
 
+    this.lastThumbarKey = null;
     this.sync(this.audioSession.getStatus());
   }
 
@@ -603,6 +604,9 @@ export const bindTaskbarPlaybackIntegration = (window: BrowserWindow): void => {
       currentIntegration = null;
     }
     integration.dispose();
+  });
+  window.on('show', () => {
+    integration.refresh();
   });
 };
 


### PR DESCRIPTION
## 问题描述

启用"显示迷你播放器"功能后，任务栏的 ECHO 图标会消失，桌面出现迷你播放器。关闭迷你播放器后，任务栏图标恢复，但**缩略图上的播放/切歌控件消失**，必须打开主窗口重新暂停/播放一次才能恢复。

## 根因分析

问题出在任务栏缩略图控件（Thumbar）与迷你播放器窗口之间的生命周期同步上：

1. 迷你播放器关闭时，主窗口重新显示，但任务栏缩略图控件的刷新逻辑没有被触发
2. `TaskbarPlaybackIntegration.refresh()` 方法未清除缓存的 thumbar key，导致后续刷新被跳过
3. 窗口 `show` 事件没有绑定缩略图控件刷新

## 修复内容

**`src/main/app/taskbarPlaybackIntegration.ts`**
- `refresh()` 方法中增加 `this.lastThumbarKey = null`，清除缓存的 thumbar key，确保每次刷新都能正确重建控件
- `bindTaskbarPlaybackIntegration()` 中增加 `window.on('show', ...)` 事件监听，窗口显示时自动刷新缩略图控件

**`src/main/app/miniPlayerWindow.ts`**
- 在迷你播放器关闭恢复主窗口时，显式调用 `refreshTaskbarPlaybackIntegration()` 确保控件立即刷新

## 测试方式

1. 启用"显示迷你播放器"功能
2. 播放一首歌曲
3. 关闭迷你播放器
4. 将鼠标悬停在任务栏 ECHO 图标上 → 缩略图控件应正常显示并可操作