### PR TITLE
fix: 修复首次播放时任务栏缩略图控件不显示的问题

### DIFF
--- a/src/main/app/taskbarPlaybackIntegration.test.ts
+++ b/src/main/app/taskbarPlaybackIntegration.test.ts
@@ -122,6 +122,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
 
     expect(window.setProgressBar).toHaveBeenCalledWith(0.25, { mode: 'normal' });
     expect(window.setTitle).toHaveBeenCalledWith('Song A - Artist A | ECHO Next');
@@ -153,6 +154,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
 
     expect(window.setTitle).toHaveBeenCalledWith('Streaming Song - Streaming Artist | ECHO Next');
     expect(window.setThumbnailToolTip).toHaveBeenCalledWith('Streaming Song - Streaming Artist | ECHO Next');
@@ -174,6 +176,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
 
     expect(window.setProgressBar).toHaveBeenCalledWith(0.5, { mode: 'paused' });
     expect(window.setTitle).toHaveBeenCalledWith('Paused Song | ECHO Next');
@@ -195,6 +198,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
 
     expect(window.setProgressBar).toHaveBeenCalledWith(-1);
     expect(window.setThumbarButtons).toHaveBeenCalledWith([]);
@@ -217,6 +221,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
 
     expect(window.setProgressBar).toHaveBeenCalledWith(-1);
     expect(window.setThumbarButtons).toHaveBeenCalledWith([]);
@@ -238,6 +243,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
     const buttons = window.setThumbarButtons.mock.calls.at(-1)?.[0] ?? [];
     buttons[0].click();
     buttons[1].click();
@@ -276,6 +282,7 @@ describe('TaskbarPlaybackIntegration', () => {
     });
 
     integration.initialize();
+    integration.refresh();
     let buttons = window.setThumbarButtons.mock.calls.at(-1)?.[0] ?? [];
     expect(buttons).toEqual(expect.arrayContaining([expect.objectContaining({ tooltip: 'Like' })]));
 
@@ -292,3 +299,4 @@ describe('TaskbarPlaybackIntegration', () => {
     integration.dispose();
   });
 });
+

--- a/src/main/app/taskbarPlaybackIntegration.ts
+++ b/src/main/app/taskbarPlaybackIntegration.ts
@@ -256,7 +256,6 @@ export class TaskbarPlaybackIntegration {
     }
 
     this.audioSession.on('status', this.handleStatus);
-    this.sync(this.audioSession.getStatus());
   }
 
   dispose(): void {


### PR DESCRIPTION
## 问题描述

打开 ECHO NEXT 播放音乐后，Windows 任务栏缩略图上没有显示播放/暂停、上一首、下一首等控件按钮。只有当用户手动开启「显示桌面迷你播放器」功能、触发窗口重新显示后，这些控件才会出现。

## 根因分析

问题出在 `TaskbarPlaybackIntegration` 的 `initialize()` 方法中。在初始化阶段，代码调用了：

```typescript
this.sync(this.audioSession.getStatus());
```

此时音频会话尚未开始播放，状态为 `stopped` 或 `idle`。`sync()` 方法检测到 `visible` 为 `false` 后，会调用 `clear()` 方法，而 `clear()` 内部会执行：

```typescript
this.window.setThumbarButtons([]);
```

这个调用会让 Windows 任务栏认为该窗口不需要缩略图控件按钮。此后即使播放状态发生变化，Windows 也不会主动重新显示这些控件 —— 除非窗口被重新创建（例如开启迷你播放器后关闭，触发窗口 `show` 事件）。

## 修复方案

删除 `initialize()` 中过早的 `sync()` 调用。缩略图控件的显示与更新由 `handleStatus` 事件处理器在音频状态变化时自然触发，不需要在初始化时主动同步一次。初始化的职责仅仅是注册事件监听。

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/main/app/taskbarPlaybackIntegration.ts` | 删除 `initialize()` 中的 `this.sync(this.audioSession.getStatus())` 调用 |
| `src/main/app/taskbarPlaybackIntegration.test.ts` | 在测试用例的 `initialize()` 后补充 `integration.refresh()` 调用，确保测试行为与修复后的实际逻辑一致 |