### PR TITLE
fix(linux): 修复打包元数据与 Sharp 运行时依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "echo-next",
   "version": "26.8.4",
   "description": "ECHO Next Phase 0 desktop music app shell.",
+  "homepage": "https://echonext.moe/zh/",
   "author": "Moekotori",
   "license": "LGPL-3.0-only",
   "main": "out/main/index.js",
@@ -142,6 +143,7 @@
       "node_modules/@lox-audioserver/node-libraop/**/*",
       "node_modules/kuromoji/dict/**/*",
       "node_modules/sharp/**/*",
+      "node_modules/@img/**/*",
       "node_modules/taglib-wasm/dist/*.wasm"
     ],
     "win": {
@@ -254,6 +256,7 @@
     },
     "linux": {
       "icon": "build-resources/icons/software.png",
+      "maintainer": "Moekotori <nyafairy233@gmail.com>",
       "extraResources": [
         {
           "from": "electron-app/build/echo-audio-host",


### PR DESCRIPTION
## 概要

在 Fedora x64 环境验证现有 Linux 打包流程时，发现了两个与 Linux 打包配置有关的问题：

1. `deb` 打包流程缺少所需的项目元数据；
2. AppImage 中 Sharp 所需的 `@img` 运行时依赖没有被完整解包，导致打包后的应用启动时无法加载 `libvips`。

本 PR 仅修改 `package.json`，共增加 3 行配置，没有修改播放器、音频后端或其他运行逻辑。

## 问题说明

### 1. `deb` 打包缺少必要的元数据

在 Linux x64 环境执行现有 Linux 打包流程时，`deb` 目标会因为缺少项目主页和 Linux 包 maintainer 信息而无法继续。

项目现有的 `package.json` 中已经包含：

```json
"author": "Moekotori"
```

但没有提供项目主页以及 Linux `deb` 包的 maintainer 信息。

本 PR 根据项目现有的公开信息补充：

```json
"homepage": "https://echonext.moe/zh/"
```

并在 Linux 打包配置中加入：

```json
"maintainer": "Moekotori <nyafairy233@gmail.com>"
```

其中 maintainer 联系方式来自项目 README 中已有的作者联系方式。

在解决上述元数据问题后，Fedora 上 electron-builder 使用的 FPM / Ruby 运行时还需要系统提供 `libcrypt.so.1`。

在 Fedora 上可以通过安装：

```bash
sudo dnf install libxcrypt-compat
```

解决。

该问题属于 Fedora 构建主机的环境依赖，不属于本 PR 修改项目配置所解决的问题，因此没有包含在本 PR 中。

### 2. AppImage 中缺少 Sharp 所需的 libvips 运行时

原有 `asarUnpack` 配置已经包含：

```text
node_modules/sharp/**/*
```

因此 Sharp 自身的 native module 可以被解包到：

```text
resources/app.asar.unpacked
```

但当前使用的 Sharp 0.34.x 还会通过 `@img` 包提供 Linux 平台相关的 native runtime 和 libvips。

本地安装的相关依赖包括：

```text
node_modules/@img/sharp-linux-x64/
node_modules/@img/sharp-libvips-linux-x64/
```

其中：

```text
node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3
```

是 Sharp Linux native module 运行时所需的动态库。

修改前检查打包产物时，可以确认：

```text
sharp-linux-x64.node
```

已经存在于：

```text
dist/linux-unpacked/resources/app.asar.unpacked/
```

但：

```text
libvips-cpp.so.8.17.3
```

没有被一起解包。

因此生成的 AppImage 虽然能够完成构建，但启动时 Sharp 会因为缺少该动态库而加载失败，错误类似：

```text
Error: Could not load the "sharp" module using the linux-x64 runtime
ERR_DLOPEN_FAILED: libvips-cpp.so.8.17.3
```

为此，本 PR 在现有 `asarUnpack` 中增加：

```text
node_modules/@img/**/*
```

使 Sharp 对应的 Linux native runtime 和 libvips 一起进入 `app.asar.unpacked`。

修改后检查打包产物，可以确认以下文件均已存在：

```text
dist/linux-unpacked/resources/app.asar.unpacked/node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node
```

以及：

```text
dist/linux-unpacked/resources/app.asar.unpacked/node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3
```

AppImage 随后可以正常启动。

## 修改内容

本 PR 仅修改 `package.json`，共增加以下 3 行：

### 1. 增加项目主页

```json
"homepage": "https://echonext.moe/zh/",
```

### 2. 将 Sharp 的 `@img` 运行时依赖加入 `asarUnpack`

```json
"node_modules/@img/**/*",
```

### 3. 增加 Linux 包 maintainer 信息

```json
"maintainer": "Moekotori <nyafairy233@gmail.com>",
```

按 `package.json` 中的层级关系，涉及的配置大致如下：

```json
{
  "author": "Moekotori",
  "homepage": "https://echonext.moe/zh/",
  "build": {
    "asarUnpack": [
      "node_modules/@clamber_l/crypto/dist/*",
      "node_modules/better-sqlite3/build/Release/*.node",
      "node_modules/@lox-audioserver/node-libraop/**/*",
      "node_modules/kuromoji/dict/**/*",
      "node_modules/sharp/**/*",
      "node_modules/@img/**/*",
      "node_modules/taglib-wasm/dist/*.wasm"
    ],
    "linux": {
      "maintainer": "Moekotori <nyafairy233@gmail.com>",
      "icon": "build-resources/icons/software.png",
      "target": [
        {
          "target": "AppImage",
          "arch": [
            "x64"
          ]
        },
        {
          "target": "deb",
          "arch": [
            "x64"
          ]
        }
      ],
      "category": "AudioVideo"
    }
  }
}
```

上面的 JSON 片段用于说明配置项所在位置；本 PR 实际仅新增 `homepage`、`node_modules/@img/**/*` 和 `maintainer` 三行。

除此之外没有修改：

- Linux 音频后端
- `echo-audio-host`
- ALSA 输出逻辑
- 播放器逻辑
- DSP
- Renderer
- Windows 音频链路
- 其他运行时功能

## 验证环境

验证环境：

```text
Fedora x64
Linux 原生环境
```

Linux 包在 Linux x64 实机环境中完成构建和运行验证。

## 验证结果

### FFmpeg 工具链

执行：

```bash
npm run verify:ffmpeg
```

验证通过。

使用的 FFmpeg 版本：

```text
ffmpeg 8.1.2
```

### Native audio engine tests

执行：

```bash
npm run test:audio-engine
```

结果：

```text
3/3 test suites passed
35/35 tests passed
0 failures
0 skipped
```

### Linux 打包

由于本地环境没有项目正式发布使用的 package integrity signing key，因此使用项目现有支持的 unsigned local package 开关进行验证：

```bash
ECHO_ALLOW_UNSIGNED_BASE_PACKAGE=1 npm run build:linux
```

构建成功完成：

```text
[build:linux] Linux build completed.
```

最终退出状态：

```text
BUILD_EXIT=0
```

成功生成：

```text
dist/ECHO NEXT-26.8.4.AppImage
dist/echo-next_26.8.4_amd64.deb
```

其中 AppImage 已确认是 x86-64 Linux 可执行产物，deb 已确认是有效的 Debian binary package。

### Sharp / libvips 打包结果

修改后确认以下文件已经进入：

```text
dist/linux-unpacked/resources/app.asar.unpacked/
```

包括：

```text
node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node
```

以及：

```text
node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3
```

AppImage 不再因为缺少 `libvips-cpp.so.8.17.3` 而在启动阶段导致 Sharp 加载失败。

### 运行验证

修改后的 AppImage 已在 Fedora x64 实机环境完成运行验证：

- AppImage 可以正常启动
- 应用可以正常进入主界面
- 本地曲库可以正常使用
- 本地音频可以正常播放

测试过程中实际播放了多个本地音频文件，没有发现由本次打包修改引入的运行问题。

### Git diff 检查

执行：

```bash
git diff --check
```

通过。

当前 PR 相对 `main` 的改动范围为：

```text
1 commit
1 file changed
3 insertions
0 deletions
```

## Fedora 构建环境补充

在 Fedora 上执行 `deb` 打包时，electron-builder 使用的 FPM / Ruby runtime 可能因为缺少：

```text
libcrypt.so.1
```

而无法启动。

本地通过：

```bash
sudo dnf install libxcrypt-compat
```

解决。

由于这一问题属于 Fedora 构建主机的兼容依赖，不属于本次 `package.json` 修改所解决的问题，因此本 PR 没有添加与此相关的项目配置。

## 备注

本 PR 的目标仅是修复现有 Linux 打包流程中的配置问题，没有尝试扩大当前 Linux 功能范围，也没有修改 Linux 音频后端。

如果项目更希望使用其他 homepage / maintainer 写法，或者希望进一步缩小 `node_modules/@img/**/*` 的 unpack 范围，我可以根据维护者意见继续调整。